### PR TITLE
improve update entity display with service name in subtitle

### DIFF
--- a/custom_components/komodo/update.py
+++ b/custom_components/komodo/update.py
@@ -60,9 +60,11 @@ class KomodoUpdateEntity(CoordinatorEntity[KomodoCoordinator], UpdateEntity):
         if service and service.update_info:
             self._attr_installed_version = service.update_info.current_version
             self._attr_latest_version = service.update_info.new_version
+            self._attr_title = f"{self._service_name}: "
         else:
             self._attr_installed_version = "0"
             self._attr_latest_version = "0"
+            self._attr_title = None
 
     async def async_install(
         self, version: str | None, backup: bool, **kwargs: Any


### PR DESCRIPTION
Currently, update entities in the Home Assistant update panel only show the stack name as the title and a generic "update available" subtitle, making it hard to identify which specific service/container has an update available without clicking into each one. Home Assistant does not give the possibility to change the full title as it will always show the device name and not the entity itself.

This PR adds ```_attr_title``` to the update entity, which populates the subtitle in the update panel list with the service name followed by the update status (e.g. ```esphome: update available``` or ```openwebui: update available```). This way, at a glance from the update panel, it is immediately clear which container inside a stack has a pending update, as visible in the screenshot below.

<img width="614" height="359" alt="image" src="https://github.com/user-attachments/assets/fe679d2d-d95c-4116-a419-f0f802b78b54" />

For comparison, here how it is in the 1.0.0-beta version:
<img width="623" height="518" alt="Image" src="https://github.com/user-attachments/assets/b1216144-4c60-4be7-b40a-fca5557d8e59" />