### PR TITLE
Allow remove devices from the UI

### DIFF
--- a/custom_components/komodo/__init__.py
+++ b/custom_components/komodo/__init__.py
@@ -7,6 +7,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .const import DOMAIN, CONF_HOST, CONF_API_KEY, CONF_API_SECRET
 from .base import KomodoBase
@@ -45,3 +46,17 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await komodo.close()
 
     return unload_ok
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, config_entry: ConfigEntry, device_entry: dr.DeviceEntry
+) -> bool:
+    """Allow removing a device (stack) from the UI."""
+    entity_reg = er.async_get(hass)
+    entities = er.async_entries_for_device(
+        entity_reg,
+        device_entry.id,
+        include_disabled_entities=True,
+    )
+    return not any(
+        entity.config_entry_id == config_entry.entry_id for entity in entities
+    )


### PR DESCRIPTION
Currently, stack devices created by the integration can be disabled in Home Assistant but not removed, as the "Delete" option is unavailable in the device UI.

This PR adds the ```async_remove_config_entry_device``` function to ```__init__.py```, which Home Assistant calls when a user attempts to delete a device. It allows removal only if the stack has no entities currently registered under the config entry — meaning the stack no longer exists in Komodo and was not recreated on the last coordinator refresh. If the stack is still active, deletion is blocked to prevent accidental removal of live stacks.

![Screenshot_2026-03-05-13-59-29-249-edit_com android chrome](https://github.com/user-attachments/assets/0de23ba7-d36d-42d8-b16c-b2adb8f107f5)