### PR TITLE
fix missing stack_count and service_count English translations

### DIFF
--- a/custom_components/komodo/translations/en.json
+++ b/custom_components/komodo/translations/en.json
@@ -31,6 +31,12 @@
             },
             "alert_list": {
                 "name": "Alerts"
+            },
+            "stack_count": {
+                "name": "Stack Count"
+            },
+            "service_count": {
+                "name": "Service Count"
             }
         },
         "switch": {


### PR DESCRIPTION
Fixed the translation file with the missing Stack Count and Service Count now showing up correctly.

<img width="1020" height="529" alt="image" src="https://github.com/user-attachments/assets/737a0ac1-4ff1-4b6e-adb8-f4e7ca47dcc2" />


Compare to before:
<img width="1210" height="796" alt="Image" src="https://github.com/user-attachments/assets/ec265758-b324-424e-baa2-205366394acb" />