### PR TITLE
fix TypeError: use alert.data.type instead of alert.id in add_alert

### DIFF
--- a/custom_components/komodo/data/server.py
+++ b/custom_components/komodo/data/server.py
@@ -28,7 +28,7 @@ class KomodoServer:
 
     def add_alert(self, alert) -> None:
         """Add an alert to this server."""
-        self.alerts.append(alert.id)
+        self.alerts.append(alert.data.type)
 
     def add_stack(self) -> None:
         """Increment stack count for this server."""

--- a/custom_components/komodo/data/stack.py
+++ b/custom_components/komodo/data/stack.py
@@ -32,7 +32,7 @@ class KomodoStack:
 
     def add_alert(self, alert) -> None:
         """Add an alert to this stack."""
-        self.alerts.append(alert.id)
+        self.alerts.append(alert.data.type)
 
     @classmethod
     def unknown(cls) -> "KomodoStack":


### PR DESCRIPTION
Fixes #31

`alert.id` is a `MongoIdObj`, not a string, causing a `TypeError` when sensor setup calls `", ".join(srv.alerts)`. Changed both `KomodoServer.add_alert` and `KomodoStack.add_alert` to append `alert.data.type` (an `AlertDataTypes` str enum), consistent with how the global `alert_list` is built in `KomodoData.add_alerts`.