### PR TITLE
Skip service inspection for stacks with no container to inspect

### DIFF
--- a/custom_components/komodo/coordinator.py
+++ b/custom_components/komodo/coordinator.py
@@ -31,6 +31,11 @@ from .data.service import KomodoService, KomodoUpdateInfo
 
 _LOGGER = logging.getLogger(__name__)
 
+# Stack states where Komodo/Docker has no container to inspect at all.
+# Inspecting a service in one of these states fails with
+# "No service found matching '<name>'", which is expected, not an error.
+_NO_CONTAINER_STATES = {"DOWN", "UNKNOWN"}
+
 
 class KomodoCoordinator(DataUpdateCoordinator[KomodoData]):
     """Komodo coordinator."""
@@ -93,10 +98,17 @@ class KomodoCoordinator(DataUpdateCoordinator[KomodoData]):
         await self._compute_update_info(data)
         await self._fetch_service_states(data)
         return data
-    
+
+    @staticmethod
+    def _stack_has_inspectable_container(stack: KomodoStack) -> bool:
+        """Return False for stack states with no container to inspect (e.g. DOWN)."""
+        return stack.state is not None and stack.state.name not in _NO_CONTAINER_STATES
+
     async def _compute_update_info(self, new_data: KomodoData):
         """Compute update info for services."""
         for stack_id, stack in new_data.stacks.items():
+            if not self._stack_has_inspectable_container(stack):
+                continue
             previous_stack = self.data.stacks[stack_id] if self.data else None
             for service_id, service in stack.services.items():
                 previous_service = previous_stack.services.get(service_id) if previous_stack else None
@@ -125,6 +137,8 @@ class KomodoCoordinator(DataUpdateCoordinator[KomodoData]):
         """Fetch service states for all services."""
         tasks = []
         for stack_id, stack in data.stacks.items():
+            if not self._stack_has_inspectable_container(stack):
+                continue
             for service in stack.services.values():
                 if service.state is None:
                     tasks.append(self._inspect_service(service, stack_id, time.time()))

--- a/custom_components/komodo/coordinator.py
+++ b/custom_components/komodo/coordinator.py
@@ -6,6 +6,7 @@ import time
 from datetime import timedelta
 from typing import List
 
+from komodo_api.exceptions import KomodoException
 from komodo_api.types import InspectStackContainer, InspectStackContainerResponse
 
 from komodo_api.lib import KomodoClient
@@ -31,10 +32,11 @@ from .data.service import KomodoService, KomodoUpdateInfo
 
 _LOGGER = logging.getLogger(__name__)
 
-# Stack states where Komodo/Docker has no container to inspect at all.
-# Inspecting a service in one of these states fails with
-# "No service found matching '<name>'", which is expected, not an error.
-_NO_CONTAINER_STATES = {"DOWN", "UNKNOWN"}
+# Substring of the error Komodo core returns when a stack has no container for
+# the service (see bin/core/src/api/read/stack.rs). The core sends it with the
+# default HTTP 500, so the message text is the only way to tell it apart from a
+# genuine internal error.
+_NO_CONTAINER_ERROR = "No service found matching"
 
 
 class KomodoCoordinator(DataUpdateCoordinator[KomodoData]):
@@ -99,30 +101,24 @@ class KomodoCoordinator(DataUpdateCoordinator[KomodoData]):
         await self._fetch_service_states(data)
         return data
 
-    @staticmethod
-    def _stack_has_inspectable_container(stack: KomodoStack) -> bool:
-        """Return False for stack states with no container to inspect (e.g. DOWN)."""
-        return stack.state is not None and stack.state.name not in _NO_CONTAINER_STATES
-
     async def _compute_update_info(self, new_data: KomodoData):
         """Compute update info for services."""
         for stack_id, stack in new_data.stacks.items():
-            if not self._stack_has_inspectable_container(stack):
-                continue
             previous_stack = self.data.stacks[stack_id] if self.data else None
             for service_id, service in stack.services.items():
                 previous_service = previous_stack.services.get(service_id) if previous_stack else None
-                await self._inspect_service_if_needed(service, stack_id, previous_service)
+                await self._inspect_service_if_needed(stack, service, stack_id, previous_service)
 
     async def _inspect_service_if_needed(
         self,
+        stack: KomodoStack,
         service: KomodoService,
         stack_id: str,
         previous_service: KomodoService | None,
     ) -> None:
         if not service.update_available:
             return
-        
+
         now = time.time()
         previous_update_info = previous_service.update_info if previous_service else None
         if (
@@ -130,14 +126,19 @@ class KomodoCoordinator(DataUpdateCoordinator[KomodoData]):
             and (now - previous_update_info.info.info_updated_at) < 7200
         ):
             service.update_info = previous_update_info
-        else:
+        elif stack.has_inspectable_container:
             await self._inspect_service(service, stack_id, now)
-    
+        else:
+            # No container to inspect (stack DOWN/UNKNOWN). Carry any cached
+            # update info forward so a pending update isn't lost while the
+            # stack is down and reported as installed=0/latest=0.
+            service.update_info = previous_update_info
+
     async def _fetch_service_states(self, data: KomodoData):
         """Fetch service states for all services."""
         tasks = []
         for stack_id, stack in data.stacks.items():
-            if not self._stack_has_inspectable_container(stack):
+            if not stack.has_inspectable_container:
                 continue
             for service in stack.services.values():
                 if service.state is None:
@@ -151,6 +152,21 @@ class KomodoCoordinator(DataUpdateCoordinator[KomodoData]):
                 InspectStackContainer(stack=stack_id, service=service.name)
             )
             _LOGGER.debug("Inspecting service %s in stack %s: %s", service.name, stack_id, response)
+        except KomodoException as e:
+            if _NO_CONTAINER_ERROR in e.error:
+                # Expected when a stack in a state we didn't guard against
+                # (e.g. UNHEALTHY, a partial deploy, or a service removed from
+                # the compose file) has no container for this service.
+                _LOGGER.debug(
+                    "No container to inspect for service %s in stack %s: %s",
+                    service.name, stack_id, e.error,
+                )
+            else:
+                _LOGGER.error(
+                    "Failed to inspect service %s in stack %s: %s",
+                    service.name, stack_id, e.error,
+                )
+            return
         except Exception as e:
             _LOGGER.error("Failed to inspect service %s in stack %s: %s", service.name, stack_id, e)
             return

--- a/custom_components/komodo/data/stack.py
+++ b/custom_components/komodo/data/stack.py
@@ -8,6 +8,12 @@ from typing import List
 from .service import KomodoService
 
 
+# Stack states with no container to inspect: DOWN (stack not deployed) and
+# UNKNOWN (server not reachable). Every other state still has a container that
+# inspects fine, including STOPPED/CREATED/DEAD/PAUSED.
+_NO_CONTAINER_STATES = frozenset({StackState.DOWN, StackState.UNKNOWN})
+
+
 class KomodoStack:
     """Wrapper for a stack list item returned from the API."""
 
@@ -25,6 +31,11 @@ class KomodoStack:
         self.server_id = item.info.server_id
         self.services = {}
         self.alerts = []
+
+    @property
+    def has_inspectable_container(self) -> bool:
+        """False when the stack has no container to inspect."""
+        return self.state is not None and self.state not in _NO_CONTAINER_STATES
 
     def add_service(self, service: "KomodoService") -> None:
         """Store a service for this stack."""

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -1,0 +1,35 @@
+import pytest
+from unittest.mock import MagicMock
+
+from komodo_api.types import StackState
+
+from custom_components.komodo.data.stack import KomodoStack
+
+
+def _stack_with_state(state):
+    item = MagicMock()
+    item.info.state = state
+    item.id = "stack_id"
+    item.name = "stack"
+    item.info.server_id = "server_id"
+    return KomodoStack(item)
+
+
+# Only DOWN (not deployed) and UNKNOWN (server unreachable) have no container.
+# Every other state, and every future-added state, is inspectable.
+@pytest.mark.parametrize("state,expected", [
+    (StackState.DEPLOYING, True),
+    (StackState.RUNNING, True),
+    (StackState.PAUSED, True),
+    (StackState.STOPPED, True),
+    (StackState.CREATED, True),
+    (StackState.RESTARTING, True),
+    (StackState.DEAD, True),
+    (StackState.REMOVING, True),
+    (StackState.UNHEALTHY, True),
+    (StackState.DOWN, False),
+    (StackState.UNKNOWN, False),
+    (None, False),
+])
+def test_has_inspectable_container(state, expected):
+    assert _stack_with_state(state).has_inspectable_container is expected


### PR DESCRIPTION
Fixes #40

## Problem

For a stack that's `DOWN` (not deployed) or `UNKNOWN` (server unreachable),
there's no container to inspect, so `inspectStackContainer` fails with
`No service found matching '<name>'. Was the stack last deployed manually?`.
`_inspect_service` caught bare `Exception`, logged `ERROR`, and never set
`service.state`, so `service.state is None` stayed true and the same failing
call was retried and logged `ERROR` every 5-minute poll cycle indefinitely.

## Fix

Three parts:

1. **Guard on `KomodoStack`, keyed on enum members.** `has_inspectable_container`
   returns `False` only for `StackState.DOWN` and `StackState.UNKNOWN`, compared
   against the `StackState` enum rather than string names, so an upstream rename
   can't silently disable it. `_fetch_service_states` skips services whose stack
   isn't inspectable.

2. **Guard moved inside `_inspect_service_if_needed`.** The previous `continue`
   on the whole stack also skipped the branch that carries a still-fresh
   `previous_update_info` forward, so a stack with a pending update that went
   `DOWN` would lose its cached version and `update.py` would report
   installed=0/latest=0. The guard now sits immediately before `_inspect_service`
   and preserves `previous_update_info` when skipping.

3. **Exception classified, log level fixed — this is what actually stops the
   loop in the general case.** The enum guard only covers `DOWN`/`UNKNOWN`; the
   same failure still occurs for `UNHEALTHY` stacks (a mix of container states),
   partial or failed deploys, and services removed from the compose file but
   still listed. `_inspect_service` now catches `komodo_api.exceptions.KomodoException`
   and, when `.error` contains `No service found matching`, logs at `DEBUG`;
   everything else stays `ERROR`. Komodo core returns this error with the default
   HTTP 500 (it's built with `anyhow!(...).into()` and no explicit status in
   `bin/core/src/api/read/stack.rs`), the same status as a genuine internal
   error, so the message text is the only reliable discriminator.

### Why `STOPPED` is deliberately not in the skip list

Issue #40 suggests skipping `STOPPED` too, but a `STOPPED` stack (like
`CREATED`, `DEAD`, `PAUSED`) still has a container that Docker inspects fine.
Only `DOWN` and `UNKNOWN` genuinely have no container, so only those two are in
`_NO_CONTAINER_STATES`.

## Testing

Parametrized unit test of `KomodoStack.has_inspectable_container` over every
`StackState` member plus `None`. It's a pure function, so no coordinator or HA
scaffolding is needed. Full suite passes.
